### PR TITLE
feat: add simple 3D battery voltage simulator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import Simulator from "./pages/Simulator";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/simulator" element={<Simulator />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 
 import React from "react";
+import { Link } from "react-router-dom";
 import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import CourseDetails from "@/components/CourseDetails";
@@ -18,6 +19,11 @@ const Index = () => {
       <Testimonials />
       <Diploma />
       <Footer />
+      <div className="text-center py-8">
+        <Link to="/simulator" className="text-blue-600 underline">
+          Ir al simulador 3D
+        </Link>
+      </div>
     </div>
   );
 };

--- a/src/pages/Simulator.tsx
+++ b/src/pages/Simulator.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useRef, useEffect } from "react";
+
+// Simple utility to compute the center of a DOMRect
+const rectCenter = (rect: DOMRect) => ({
+  x: rect.left + rect.width / 2,
+  y: rect.top + rect.height / 2,
+});
+
+const distance = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+  Math.hypot(a.x - b.x, a.y - b.y);
+
+const Simulator = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const positiveRef = useRef<HTMLDivElement>(null);
+  const negativeRef = useRef<HTMLDivElement>(null);
+  const redRef = useRef<HTMLDivElement>(null);
+  const blackRef = useRef<HTMLDivElement>(null);
+
+  const [redPos, setRedPos] = useState({ x: 50, y: 50 });
+  const [blackPos, setBlackPos] = useState({ x: 100, y: 50 });
+  const [dragging, setDragging] = useState<"red" | "black" | null>(null);
+  const [connected, setConnected] = useState(false);
+
+  // Update probe position while dragging
+  useEffect(() => {
+    const handleMove = (e: PointerEvent) => {
+      if (!dragging || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      if (dragging === "red") setRedPos({ x, y });
+      if (dragging === "black") setBlackPos({ x, y });
+    };
+    const handleUp = () => setDragging(null);
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    return () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+    };
+  }, [dragging]);
+
+  // Check if probes touch terminals
+  useEffect(() => {
+    if (
+      !positiveRef.current ||
+      !negativeRef.current ||
+      !redRef.current ||
+      !blackRef.current
+    )
+      return;
+    const pos = rectCenter(positiveRef.current.getBoundingClientRect());
+    const neg = rectCenter(negativeRef.current.getBoundingClientRect());
+    const red = rectCenter(redRef.current.getBoundingClientRect());
+    const black = rectCenter(blackRef.current.getBoundingClientRect());
+    const touchingPositive = distance(pos, red) < 20;
+    const touchingNegative = distance(neg, black) < 20;
+    setConnected(touchingPositive && touchingNegative);
+  }, [redPos, blackPos]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full h-screen overflow-hidden bg-gray-100 touch-none"
+    >
+      {/* Car body */}
+      <div
+        className="absolute left-1/2 top-1/2 w-72 h-40 -translate-x-1/2 -translate-y-1/2 bg-blue-400" 
+        style={{
+          transformStyle: "preserve-3d",
+          transform: "rotateX(20deg) rotateY(-20deg)",
+        }}
+      >
+        {/* HV Battery */}
+        <div
+          className="absolute w-32 h-16 bg-yellow-400 left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        >
+          <div
+            ref={positiveRef}
+            className="absolute w-4 h-4 bg-red-600 rounded-full -top-2 left-4"
+          />
+          <div
+            ref={negativeRef}
+            className="absolute w-4 h-4 bg-black rounded-full -top-2 right-4"
+          />
+        </div>
+      </div>
+
+      {/* Probes */}
+      <div
+        ref={redRef}
+        onPointerDown={() => setDragging("red")}
+        className="absolute w-5 h-5 bg-red-600 rounded-full cursor-pointer"
+        style={{ left: redPos.x - 10, top: redPos.y - 10 }}
+      />
+      <div
+        ref={blackRef}
+        onPointerDown={() => setDragging("black")}
+        className="absolute w-5 h-5 bg-black rounded-full cursor-pointer"
+        style={{ left: blackPos.x - 10, top: blackPos.y - 10 }}
+      />
+
+      {/* Multimeter display */}
+      <div className="absolute bottom-4 right-4 bg-gray-900 text-green-400 font-mono p-4 rounded">
+        {connected ? "400V" : "---"}
+      </div>
+    </div>
+  );
+};
+
+export default Simulator;
+


### PR DESCRIPTION
## Summary
- add basic CSS-driven 3D electric car simulator with draggable multimeter probes
- expose simulator route and link from the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: linter errors in pre-existing files)*
- `npx eslint src/App.tsx src/pages/Index.tsx src/pages/Simulator.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688d7856c0408326830d87ace3edbce6